### PR TITLE
check if `navigator.getVRDevices` is actually a promise

### DIFF
--- a/cssvr.js
+++ b/cssvr.js
@@ -61,7 +61,7 @@
       camera.appendChild(world);
     }
 
-    if (navigator.getVRDevices) {
+    if (navigator.getVRDevices && navigator.getVRDevices.then) {
       navigator.getVRDevices().then(function(devices) {
         vrDevices.headset = devices[0];
         vrDevices.position = devices[1];


### PR DESCRIPTION
so switching from Nightly to Firefox 39 (stable) works in same profile
